### PR TITLE
Request to Merge

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -707,10 +707,8 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                 Optional<DataExtractSubstituteParameter> dataExtract = getDataExtractSubstituteParameter(
                         dataExtractSubstituteParams, operationId);
 
-                // calculate order for this current request
-                Integer requestOrder = calculateRequestOrder(operationGroupingOrder, requests.size());
-
-                requests.put(requestOrder, new HTTPRequest(
+                // create requests
+                requests.putIfAbsent(requests.size(), new HTTPRequest(
                     operationId,
                     method.toString().toLowerCase(Locale.ROOT),
                     path,
@@ -933,7 +931,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
             existingHTTPRequestGroup.addRequests(requests);
             existingHTTPRequestGroup.addVariables(variables);
         } else {
-            requestGroups.put(groupName, new HTTPRequestGroup(groupName, variables, requests));
+            requestGroups.putIfAbsent(groupName, new HTTPRequestGroup(groupName, variables, requests));
         }
     }
 
@@ -1127,36 +1125,6 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
     }
 
-    /**
-     * Calculate order for this current request
-     *
-     * @param operationGroupingOrder
-     * @param requestsSize
-     * @return request order
-     */
-    private Integer calculateRequestOrder(OptionalInt operationGroupingOrder, int requestsSize) {
-        int requestOrder;
-
-        if (operationGroupingOrder.isPresent()) {
-            requestOrder = operationGroupingOrder.getAsInt() - 1;
-
-        } else {
-            switch (requestsSize) {
-                case 0:
-                case 1:
-                    requestOrder = requestsSize;
-                    break;
-
-                default:
-                    requestOrder = (requestsSize - 1);
-                    break;
-            }
-        }
-
-        return requestOrder;
-    }
-
-    //
 
     /**
      * Any variables not defined yet but used for subsequent data extraction must be


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed the `calculateRequestOrder` function as it was redundant and unnecessary.
- Improved request handling by using `putIfAbsent` for both requests and request groups to ensure no overwriting occurs.
- Addressed a bug related to request order calculation as described in issue #19110.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>K6ClientCodegen.java</strong><dd><code>Remove redundant function and improve request handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java

<li>Removed the <code>calculateRequestOrder</code> function due to redundancy.<br> <li> Replaced <code>requests.put</code> with <code>requests.putIfAbsent</code> for request creation.<br> <li> Replaced <code>requestGroups.put</code> with <code>requestGroups.putIfAbsent</code> for group <br>creation.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/openapi-generator/pull/1/files#diff-815b53fdfa29a1e4046c5b8549e551ca533fe0590e723364cc2c0c57852abe6b">+3/-35</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information